### PR TITLE
Fix schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Update JSON source schemas for S3 transfers.
+
 ## v0.5.0
 
 - Updated linting and workflows to match `opentaskpy` repo standards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.5.0"
+current_version = "0.5.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -123,6 +123,8 @@ class S3Transfer(RemoteTransferHandler):
         }
         if directory:
             kwargs["Prefix"] = directory
+        elif str(self.spec["directory"]):
+            kwargs["Prefix"] = str(self.spec["directory"])
 
         remote_files = {}
 

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination.json
@@ -6,8 +6,9 @@
     "bucket": {
       "type": "string"
     },
-    "path": {
-      "type": "string"
+    "directory": {
+      "type": "string",
+      "default": ""
     },
     "flags": {
       "$ref": "s3_destination/flags.json"
@@ -17,5 +18,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["bucket", "path", "protocol"]
+  "required": ["bucket", "protocol"]
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source.json
@@ -6,8 +6,9 @@
     "bucket": {
       "type": "string"
     },
-    "path": {
-      "type": "string"
+    "directory": {
+      "type": "string",
+      "default": ""
     },
     "fileRegex": {
       "type": "string"
@@ -26,5 +27,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["bucket", "path", "fileRegex", "protocol"]
+  "required": ["bucket", "fileRegex", "protocol"]
 }

--- a/test/cfg/transfers/s3-file-watch.json
+++ b/test/cfg/transfers/s3-file-watch.json
@@ -2,9 +2,9 @@
   "type": "transfer",
   "source": {
     "bucket": "test-bucket",
+    "directory": "src",
     "fileWatch": {
       "timeout": 15,
-      "directory": "src",
       "fileRegex": ".*\\.txt"
     },
     "protocol": {

--- a/test/cfg/transfers/s3-to-s3-copy.json
+++ b/test/cfg/transfers/s3-to-s3-copy.json
@@ -2,7 +2,7 @@
   "type": "transfer",
   "source": {
     "bucket": "test-bucket",
-    "path": "/src",
+    "directory": "/src",
     "fileRegex": ".*\\.txt",
     "protocol": {
       "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer"
@@ -11,7 +11,7 @@
   "destination": [
     {
       "bucket": "test-bucket-2",
-      "path": "/dest",
+      "directory": "/dest",
       "protocol": {
         "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer"
       }

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -29,13 +29,13 @@ s3_file_watch_task_definition = {
     "type": "transfer",
     "source": {
         "bucket": BUCKET_NAME,
+        "directory": "src",
+        "fileRegex": ".*\\.txt",
         "protocol": {
             "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
         },
         "fileWatch": {
             "timeout": 10,
-            "directory": "src",
-            "fileRegex": ".*\\.txt",
         },
     },
 }

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -14,7 +14,7 @@ def valid_protocol_definition():
 def valid_transfer(valid_protocol_definition):
     return {
         "bucket": "test-bucket",
-        "path": "/src",
+        "directory": "/src",
         "fileRegex": ".*\\.txt",
         "protocol": valid_protocol_definition,
     }
@@ -24,7 +24,7 @@ def valid_transfer(valid_protocol_definition):
 def valid_destination(valid_protocol_definition):
     return {
         "bucket": "test-bucket",
-        "path": "/dest",
+        "directory": "/dest",
         "protocol": valid_protocol_definition,
     }
 


### PR DESCRIPTION
Closing #4 

Rename the `path` attribute to `directory` to be consistent with the base schema, and so things like filewatches will work properly if no `directory` is specified in the `fileWatch` object.
Sort out JSON schema for S3 source so that destination is optional, but also defaults to an empty string if it isn't defined.

