### PR TITLE
Add support for AssumeRole in AWS remote handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.0
+
+- Add ability to use AssumeRole in protocol definition
+
 ## v0.6.1
 
 - Increase timeout for lambda function creation test

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Credentials can be set via config using equivalently named variables alongside t
     "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
     "access_key_id": "some_key",
     "secret_access_key": "some_secret_key",
+    "assume_role_arn": "arn:aws:iam::000000000000:role/some_role",
     "region_name": "eu-west-1"
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -56,7 +56,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.6.1"
+current_version = "0.7.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/creds.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/creds.py
@@ -1,4 +1,5 @@
 """AWS helper functions."""
+
 import os
 
 
@@ -18,6 +19,12 @@ def set_aws_creds(obj) -> None:  # type: ignore[no-untyped-def]
         obj.spec["protocol"]["secret_access_key"]
         if "secret_access_key" in obj.spec["protocol"]
         else os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+    obj.assume_role_arn = (
+        obj.spec["protocol"]["assume_role_arn"]
+        if "asssume_role_arn" in obj.spec["protocol"]
+        else os.environ.get("AWS_ROLE_ARN")
     )
 
     obj.region_name = (

--- a/src/opentaskpy/addons/aws/remotehandlers/lambda.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/lambda.py
@@ -1,7 +1,9 @@
 """AWS Lambda remote handler."""
+
 import base64
 import json
 import os
+from time import time
 
 import boto3
 import botocore.exceptions
@@ -60,6 +62,12 @@ class LambdaExecution(RemoteExecutionHandler):
         self.session = boto3.session.Session(**kwargs)
 
         self.lambda_client = self.session.client("lambda", **kwargs2)
+
+        # If we have an assume role, then we need to assume it
+        if self.assume_role_arn:
+            self.lambda_client.assume_role(
+                RoleArn=self.assume_role_arn, RoleSessionName=f"OTF{time()}"
+            )
 
     def kill(self) -> None:
         """Kill the lambda function.

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -1,7 +1,9 @@
 """AWS S3 remote handler."""
+
 import glob
 import os
 import re
+from time import time
 
 import boto3
 import opentaskpy.otflogging
@@ -49,6 +51,12 @@ class S3Transfer(RemoteTransferHandler):
         self.session = boto3.session.Session(**kwargs)
 
         self.s3_client = self.session.client("s3", **kwargs2)
+
+        # If we have an assume role, then we need to assume it
+        if self.assume_role_arn:
+            self.s3_client.assume_role(
+                RoleArn=self.assume_role_arn, RoleSessionName=f"OTF{time()}"
+            )
 
     def supports_direct_transfer(self) -> bool:
         """Return True, as you can do bucket to bucket transfers."""

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
@@ -15,10 +15,67 @@
     "secret_access_key": {
       "type": "string"
     },
+    "assume_role_arn": {
+      "type": "string"
+    },
     "region_name": {
       "type": "string"
     }
   },
+  "oneOf": [
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    }
+  ],
   "required": ["name"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
@@ -22,60 +22,22 @@
       "type": "string"
     }
   },
-  "oneOf": [
+  "required": ["name"],
+  "additionalProperties": false,
+  "allOf": [
     {
-      "properties": {
-        "access_key_id": {
-          "not": {}
+      "if": {
+        "properties": {
+          "access_key_id": { "type": "string" }
         },
-        "secret_access_key": {
-          "not": {}
+        "required": ["access_key_id"]
+      },
+      "then": {
+        "properties": {
+          "secret_access_key": { "type": "string" }
         },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "not": {}
-        },
-        "secret_access_key": {
-          "not": {}
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
+        "required": ["secret_access_key"]
       }
     }
-  ],
-  "required": ["name"],
-  "additionalProperties": false
+  ]
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
@@ -13,10 +13,67 @@
     "secret_access_key": {
       "type": "string"
     },
+    "assume_role_arn": {
+      "type": "string"
+    },
     "region_name": {
       "type": "string"
     }
   },
+  "oneOf": [
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    }
+  ],
   "required": ["name"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
@@ -20,60 +20,22 @@
       "type": "string"
     }
   },
-  "oneOf": [
+  "required": ["name"],
+  "additionalProperties": false,
+  "allOf": [
     {
-      "properties": {
-        "access_key_id": {
-          "not": {}
+      "if": {
+        "properties": {
+          "access_key_id": { "type": "string" }
         },
-        "secret_access_key": {
-          "not": {}
+        "required": ["access_key_id"]
+      },
+      "then": {
+        "properties": {
+          "secret_access_key": { "type": "string" }
         },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "not": {}
-        },
-        "secret_access_key": {
-          "not": {}
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
+        "required": ["secret_access_key"]
       }
     }
-  ],
-  "required": ["name"],
-  "additionalProperties": false
+  ]
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/s3/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/s3/protocol.json
@@ -13,10 +13,67 @@
     "secret_access_key": {
       "type": "string"
     },
+    "assume_role_arn": {
+      "type": "string"
+    },
     "region_name": {
       "type": "string"
     }
   },
+  "oneOf": [
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    }
+  ],
   "required": ["name"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/s3/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/s3/protocol.json
@@ -20,60 +20,22 @@
       "type": "string"
     }
   },
-  "oneOf": [
+  "required": ["name"],
+  "additionalProperties": false,
+  "allOf": [
     {
-      "properties": {
-        "access_key_id": {
-          "not": {}
+      "if": {
+        "properties": {
+          "access_key_id": { "type": "string" }
         },
-        "secret_access_key": {
-          "not": {}
+        "required": ["access_key_id"]
+      },
+      "then": {
+        "properties": {
+          "secret_access_key": { "type": "string" }
         },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "not": {}
-        },
-        "secret_access_key": {
-          "not": {}
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
+        "required": ["secret_access_key"]
       }
     }
-  ],
-  "required": ["name"],
-  "additionalProperties": false
+  ]
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
@@ -18,65 +18,24 @@
     },
     "region_name": {
       "type": "string"
-    },
-    "bucket_owner_full_control": {
-      "type": "boolean"
     }
   },
-  "oneOf": [
+  "required": ["name"],
+  "additionalProperties": false,
+  "allOf": [
     {
-      "properties": {
-        "access_key_id": {
-          "not": {}
+      "if": {
+        "properties": {
+          "access_key_id": { "type": "string" }
         },
-        "secret_access_key": {
-          "not": {}
+        "required": ["access_key_id"]
+      },
+      "then": {
+        "properties": {
+          "secret_access_key": { "type": "string" }
         },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "not": {}
-        },
-        "secret_access_key": {
-          "not": {}
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "not": {}
-        }
-      }
-    },
-    {
-      "properties": {
-        "access_key_id": {
-          "type": "string"
-        },
-        "secret_access_key": {
-          "type": "string"
-        },
-        "assume_role_arn": {
-          "type": "string"
-        }
+        "required": ["secret_access_key"]
       }
     }
-  ],
-  "required": ["name"],
-  "additionalProperties": false
+  ]
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
@@ -13,6 +13,9 @@
     "secret_access_key": {
       "type": "string"
     },
+    "assume_role_arn": {
+      "type": "string"
+    },
     "region_name": {
       "type": "string"
     },
@@ -20,6 +23,60 @@
       "type": "boolean"
     }
   },
+  "oneOf": [
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "not": {}
+        },
+        "secret_access_key": {
+          "not": {}
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "not": {}
+        }
+      }
+    },
+    {
+      "properties": {
+        "access_key_id": {
+          "type": "string"
+        },
+        "secret_access_key": {
+          "type": "string"
+        },
+        "assume_role_arn": {
+          "type": "string"
+        }
+      }
+    }
+  ],
   "required": ["name"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
@@ -13,10 +13,29 @@
     "secret_access_key": {
       "type": "string"
     },
+    "assume_role_arn": {
+      "type": "string"
+    },
     "region_name": {
       "type": "string"
     }
   },
   "required": ["name"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "access_key_id": { "type": "string" }
+        },
+        "required": ["access_key_id"]
+      },
+      "then": {
+        "properties": {
+          "secret_access_key": { "type": "string" }
+        },
+        "required": ["secret_access_key"]
+      }
+    }
+  ]
 }

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -11,6 +11,41 @@ def valid_protocol_definition():
 
 
 @pytest.fixture(scope="function")
+def valid_protocol_definition_using_keys():
+    return {
+        "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+        "access_key_id": "12345",
+        "secret_access_key": "12345",
+    }
+
+
+@pytest.fixture(scope="function")
+def invalid_protocol_definition_using_keys_no_secret():
+    return {
+        "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+        "access_key_id": "12345",
+    }
+
+
+@pytest.fixture(scope="function")
+def valid_protocol_definition_using_assume_role():
+    return {
+        "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+        "assume_role_arn": "12345",
+    }
+
+
+@pytest.fixture(scope="function")
+def valid_protocol_definition_using_assume_role_and_keys():
+    return {
+        "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+        "assume_role_arn": "12345",
+        "access_key_id": "12345",
+        "secret_access_key": "12345",
+    }
+
+
+@pytest.fixture(scope="function")
 def valid_transfer(valid_protocol_definition):
     return {
         "bucket": "test-bucket",
@@ -27,6 +62,33 @@ def valid_destination(valid_protocol_definition):
         "directory": "/dest",
         "protocol": valid_protocol_definition,
     }
+
+
+def test_s3_source_protocol(
+    valid_transfer,
+    valid_protocol_definition_using_assume_role,
+    valid_protocol_definition_using_keys,
+    invalid_protocol_definition_using_keys_no_secret,
+    valid_protocol_definition_using_assume_role_and_keys,
+):
+    json_data = {
+        "type": "transfer",
+        "source": valid_transfer,
+    }
+
+    json_data["source"]["protocol"] = valid_protocol_definition_using_assume_role
+    assert validate_transfer_json(json_data)
+
+    json_data["source"]["protocol"] = valid_protocol_definition_using_keys
+    assert validate_transfer_json(json_data)
+
+    json_data["source"][
+        "protocol"
+    ] = valid_protocol_definition_using_assume_role_and_keys
+    assert validate_transfer_json(json_data)
+
+    json_data["source"]["protocol"] = invalid_protocol_definition_using_keys_no_secret
+    assert not validate_transfer_json(json_data)
 
 
 def test_s3_source_basic(valid_transfer):


### PR DESCRIPTION
This pull request adds support for AssumeRole in the AWS remote handlers. With this feature, users can now specify an AssumeRole ARN in the protocol definition, allowing them to assume a specific role when interacting with AWS services. This provides an additional layer of security and flexibility when working with AWS resources.