### PR TITLE
Add support for forcing S3 transfers to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.2
+
+- Allow forcing S3 transfers to proxy rather than using CopyObject. This prevents permission issues when trying to do cross account transfers where also using AssumeRole.
+
 ## v0.7.1
 
 - Ensure AssumeRole gets run and creds created correctly

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination.json
@@ -13,6 +13,10 @@
     "flags": {
       "$ref": "s3_destination/flags.json"
     },
+    "transferType": {
+      "type": "string",
+      "enum": ["proxy", "push"]
+    },
     "protocol": {
       "$ref": "s3_destination/protocol.json"
     }


### PR DESCRIPTION
This pull request adds support for forcing S3 transfers to proxy instead of using CopyObject. This is particularly useful when performing cross-account transfers with AssumeRole, as it prevents permission issues. The changes include updates to the `s3_destination` schema to include a new `transferType` field with options for "proxy" or "push". Additionally, a new test case `test_s3_to_s3_proxy` is added to verify the functionality. This PR addresses the following commits:

- v0.7.2: Allow forcing S3 transfers to proxy rather than using CopyObject. This prevents permission issues when trying to do cross-account transfers where also using AssumeRole.