### PR TITLE
Handle newline characters in SSM better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.8.0
+
+- Handle paramstore responses with newlines better
+
 ## v24.5.1
 
 - Ensure that S3 listing only matches the file we want, and not ones in lower directory trees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.5.1"
+version = "v24.8.0"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -56,7 +56,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.5.1"
+current_version = "v24.8.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/plugins/lookup/aws/ssm.py
+++ b/src/opentaskpy/plugins/lookup/aws/ssm.py
@@ -4,6 +4,8 @@ Uses boto3 to pull out a parameter from AWS Parameter Store
 This uses AWS authentication, either from the IAM role of the host,
 by using environment variables, or variables in variables.json file
 """
+
+import json
 import os
 
 import boto3
@@ -83,5 +85,13 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
         raise e
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.error(f"Failed to read from SSM parameter: {kwargs['name']}: {e}")
+
+    # Escape any escape characters so they can be stored in JSON as a string
+    if result:
+        # Escape any newline characters
+        result = result.replace("\n", "\\n")
+        result = json.dumps(result)
+        # Remove the leading and trailing quotes
+        result = result[1:-1]
 
     return result

--- a/tests/test_plugin_ssm.py
+++ b/tests/test_plugin_ssm.py
@@ -79,7 +79,7 @@ def test_config_loader_using_ssm_plugin(ssm_client, tmpdir):
         ]
     )
     # Test with a multi line string to make sure that it doesn't break the parser
-    expected_result = "config_loader_test_1234\nanother_line"
+    expected_result = """config_loader_test_1234\\nanother_line"""
 
     # Insert the param into paramstore
     ssm_client.put_parameter(

--- a/tests/test_plugin_ssm.py
+++ b/tests/test_plugin_ssm.py
@@ -78,7 +78,8 @@ def test_config_loader_using_ssm_plugin(ssm_client, tmpdir):
             },
         ]
     )
-    expected_result = "config_loader_test_1234"
+    # Test with a multi line string to make sure that it doesn't break the parser
+    expected_result = "config_loader_test_1234\nanother_line"
 
     # Insert the param into paramstore
     ssm_client.put_parameter(


### PR DESCRIPTION
This pull request fixes an issue with handling newline characters in SSM. Previously, newline characters were not properly escaped when storing them in JSON. This caused problems when retrieving the values from SSM. With this fix, newline characters are properly escaped and stored as "\\n" in JSON.