### PR TITLE
Fix token refreshing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.12.0
+
+- Fix temporary token not refreshing correctly
+
 ## v24.10.1
 
 - More logging updates to handle major logging change in `opentaskpy` v24.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v24.12.0
+## v24.13.0
 
 - Fix temporary token not refreshing correctly
+- Implement required breaking changes from `opentaskpy` v24.13.1
 
 ## v24.10.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 keywords = ["automation", "task", "framework", "aws", "s3", "ssm", "otf"]
-dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.10.0"]
+dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.13.1"]
 description = "Addons for opentaskpy, giving it the ability to push/pull via AWS S3, and pull variables from AWS SSM Parameter Store."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.10.1"
+version = "v24.13.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -52,7 +52,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.10.1"
+current_version = "v24.13.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -311,12 +311,15 @@ class S3Transfer(RemoteTransferHandler):
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def push_files_from_worker(self, local_staging_directory: str) -> int:
+    def push_files_from_worker(
+        self, local_staging_directory: str, file_list: dict | None = None
+    ) -> int:
         """Push files from the worker to the destination server.
 
         Args:
             local_staging_directory (str): The local staging directory to upload the
             files from.
+            file_list (dict, optional): The list of files to transfer. Defaults to None.
 
         Returns:
             int: 0 if successful, 1 if not.


### PR DESCRIPTION
This pull request addresses the issue where the token doesn't appear to be refreshing in the long running filewatch for S3 using assumed role. The code changes ensure that the temporary token is correctly refreshed.

Fixes #30