### PR TITLE
Add wider window for refreshing token in AWS remote handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.16.0
+
+- Added a wider window for refreshing token. If it's within 60 seconds of expiry when checking we will refresh it, so handle instances where there's a delay renewing.
+
 ## v24.15.0
 
 - Fix issue where too many files were being uploaded from worker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.15.0"
+version = "v24.16.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.15.0"
+current_version = "v24.16.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/ecsfargate.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/ecsfargate.py
@@ -1,6 +1,6 @@
 """AWS Fargate Task remote handler."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from time import sleep
 
 import boto3
@@ -62,7 +62,8 @@ class FargateTaskExecution(RemoteExecutionHandler):
 
         if not self.ecs_client or (
             self.temporary_creds
-            and self.temporary_creds["Expiration"] < datetime.now(tz=tzlocal())
+            and self.temporary_creds["Expiration"]
+            < datetime.now(tz=tzlocal()) + timedelta(minutes=1)
         ):
 
             if self.temporary_creds:

--- a/src/opentaskpy/addons/aws/remotehandlers/lambda.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/lambda.py
@@ -2,7 +2,7 @@
 
 import base64
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import boto3
 import opentaskpy.otflogging
@@ -73,7 +73,8 @@ class LambdaExecution(RemoteExecutionHandler):
 
         if not self.lambda_client or (
             self.temporary_creds
-            and self.temporary_creds["Expiration"] < datetime.now(tz=tzlocal())
+            and self.temporary_creds["Expiration"]
+            < datetime.now(tz=tzlocal()) + timedelta(minutes=1)
         ):
 
             if self.temporary_creds:

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -3,7 +3,7 @@
 import glob
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import boto3
 import opentaskpy.otflogging
@@ -65,7 +65,8 @@ class S3Transfer(RemoteTransferHandler):
 
         if not self.s3_client or (
             self.temporary_creds
-            and self.temporary_creds["Expiration"] < datetime.now(tz=tzlocal())
+            and self.temporary_creds["Expiration"]
+            < datetime.now(tz=tzlocal()) + timedelta(minutes=1)
         ):
 
             if self.temporary_creds:
@@ -522,7 +523,8 @@ class S3Execution(RemoteExecutionHandler):
 
         if not self.s3_client or (
             self.temporary_creds
-            and self.temporary_creds["Expiration"] < datetime.now(tz=tzlocal())
+            and self.temporary_creds["Expiration"]
+            < datetime.now(tz=tzlocal()) + timedelta(minutes=1)
         ):
 
             if self.temporary_creds:


### PR DESCRIPTION
This pull request adds a wider window for refreshing the token in the AWS remote handlers. Previously, the token was only refreshed if it was basically about to expire, or had expired already. 

With this change, the token will be refreshed if it is within 60 seconds of expiry, allowing for potential delays in token renewal.