### PR TITLE
Add SSM cacheable variables plugin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,14 @@
         "esbenp.prettier-vscode"
       ],
       "settings": {
-        "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
+        "python.testing.unittestArgs": [
+          "-v",
+          "-s",
+          "tests",
+          "-p",
+          "test_*.py",
+          "--keepalive"
+        ],
         "python.defaultInterpreterPath": "/usr/local/bin/python",
         "python.testing.unittestEnabled": false,
         "python.testing.pytestArgs": ["."],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v24.22.0
+
+- Added new cacheable plugin to allow dynamically updated variables to be written back to SSM Parameter Store/Secrets Manager. For more detail see `open-task-framework` documentation for version 24.22.0
+- Minor tweaks to SSM lookup plugin
+
 ## v24.19.0
 
 - Removed a stray `break` in S3 file listing that was preventing fetching more than the first 1000 records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v24.22.0
+## v24.23.0
 
 - Added new cacheable plugin to allow dynamically updated variables to be written back to SSM Parameter Store/Secrets Manager. For more detail see `open-task-framework` documentation for version 24.22.0
 - Minor tweaks to SSM lookup plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 keywords = ["automation", "task", "framework", "aws", "s3", "ssm", "otf"]
-dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.22.0"]
+dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.23.0"]
 description = "Addons for opentaskpy, giving it the ability to push/pull via AWS S3, and pull variables from AWS SSM Parameter Store."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.19.0"
+version = "v24.23.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.19.0"
+current_version = "v24.23.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 keywords = ["automation", "task", "framework", "aws", "s3", "ssm", "otf"]
-dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.13.1"]
+dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.22.0"]
 description = "Addons for opentaskpy, giving it the ability to push/pull via AWS S3, and pull variables from AWS SSM Parameter Store."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/opentaskpy/plugins/lookup/aws/ssm.py
+++ b/src/opentaskpy/plugins/lookup/aws/ssm.py
@@ -27,12 +27,12 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
 
     Raises:
         LookupPluginError: Returned if the kwarg 'name' is not provided
-        FileNotFoundError: Returned if the file does not exist
+        ClientError: Returned if the parameter does not exist
 
     Returns:
-        _type_: The value read from the file
+        _type_: The value read from Parameter Store
     """
-    # Expect a kwarg named url, and value
+    # Expect a kwarg named name
     expected_kwargs = ["name"]
     for kwarg in expected_kwargs:
         if kwarg not in kwargs:
@@ -41,7 +41,7 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
                 f" '{plugin_name}'"
             )
 
-    globals_ = kwargs["globals"] if "globals" in kwargs else None
+    globals_ = kwargs.get("globals", None)
 
     aws_access_key_id = (
         globals_["AWS_ACCESS_KEY_ID"]

--- a/src/opentaskpy/variablecaching/aws/ssm.py
+++ b/src/opentaskpy/variablecaching/aws/ssm.py
@@ -1,0 +1,81 @@
+"""Caching plugin for writing variables to AWS SSM."""
+
+import os
+
+import boto3
+import opentaskpy.otflogging
+from botocore.exceptions import ClientError
+from opentaskpy.exceptions import CachingPluginError
+
+logger = opentaskpy.otflogging.init_logging(__name__)
+
+CACHE_NAME = "ssm"
+
+
+def run(**kwargs):  # type: ignore[no-untyped-def]
+    """Write a variable to AWS SSM.
+
+    Args:
+        **kwargs: Expect kwargs named 'name', and 'value'. This should be the Parameter
+         Store parameter value to write to, and the value to put into the file
+
+    Raises:
+        CachingPluginError: Returned if the kwarg 'name' or 'value' is not provided
+        FileNotFoundError: Returned if the file does not exist
+    """
+    # Expect a kwarg named name, and value
+    expected_kwargs = ["name", "value"]
+    for kwarg in expected_kwargs:
+        if kwarg not in kwargs:
+            raise CachingPluginError(
+                f"Missing kwarg: '{kwarg}' while trying to run caching plugin"
+                f" '{CACHE_NAME}'"
+            )
+
+    globals_ = kwargs.get("globals", None)
+
+    aws_access_key_id = (
+        globals_["AWS_ACCESS_KEY_ID"]
+        if globals_ and "AWS_ACCESS_KEY_ID" in globals_
+        else os.environ.get("AWS_ACCESS_KEY_ID")
+    )
+    aws_secret_access_key = (
+        globals_["AWS_SECRET_ACCESS_KEY"]
+        if globals_ and "AWS_SECRET_ACCESS_KEY" in globals_
+        else os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+    region_name = (
+        globals_["AWS_REGION"]
+        if globals_ and "AWS_REGION" in globals_
+        else os.environ.get("AWS_REGION")
+    )
+    boto3_kwargs = {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+        "region_name": region_name,
+    }
+    # If there's an override for endpoint_url in the environment, then use that
+    kwargs2 = {}
+    if os.environ.get("AWS_ENDPOINT_URL"):
+        kwargs2["endpoint_url"] = os.environ.get("AWS_ENDPOINT_URL")
+
+    try:
+        session = boto3.session.Session(**boto3_kwargs)
+        ssm = session.client("ssm", **kwargs2)
+
+        # Write the value to the SSM parameter
+        ssm.put_parameter(
+            Name=kwargs["name"],
+            Value=kwargs["value"],
+            Type="SecureString",
+            Overwrite=True,
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ParameterNotFound":
+            logger.error(f"Parameter not found: {kwargs['name']}: {e}")
+            raise e
+        raise e
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(f"Failed to write SSM parameter: {kwargs['name']}: {e}")
+        raise e

--- a/src/opentaskpy/variablecaching/aws/vc_ssm.py
+++ b/src/opentaskpy/variablecaching/aws/vc_ssm.py
@@ -9,7 +9,7 @@ from opentaskpy.exceptions import CachingPluginError
 
 logger = opentaskpy.otflogging.init_logging(__name__)
 
-CACHE_NAME = "ssm"
+CACHE_NAME = "vc_ssm"
 
 
 def run(**kwargs):  # type: ignore[no-untyped-def]

--- a/tests/test_cacheable_variable_ssm.py
+++ b/tests/test_cacheable_variable_ssm.py
@@ -4,20 +4,20 @@
 from botocore.exceptions import ClientError
 from opentaskpy.exceptions import CachingPluginError
 
-from opentaskpy.variablecaching.aws import ssm
+from opentaskpy.variablecaching.aws import vc_ssm
 from tests.fixtures.localstack import *  # noqa: F403
 
 
 def test_cacheable_variable_ssm_args():
     # Test combinations of the plugin with invalid args
     with pytest.raises(CachingPluginError):
-        ssm.run()
+        vc_ssm.run()
 
     with pytest.raises(CachingPluginError):
-        ssm.run(name="/test/variable")
+        vc_ssm.run(name="/test/variable")
 
     with pytest.raises(CachingPluginError):
-        ssm.run(value="newvalue")
+        vc_ssm.run(value="newvalue")
 
 
 def test_cacheable_variable_ssm(ssm_client):
@@ -36,7 +36,7 @@ def test_cacheable_variable_ssm(ssm_client):
 
     kwargs = {"name": f"/test/variable", "value": "newvalue"}
 
-    ssm.run(**kwargs)
+    vc_ssm.run(**kwargs)
 
     # Check the variable has content of "newvalue"
     assert (
@@ -57,4 +57,4 @@ def test_cacheable_variable_ssm_failure(ssm_client):
     del os.environ["AWS_ENDPOINT_URL"]
 
     with pytest.raises(ClientError):
-        ssm.run(**kwargs)
+        vc_ssm.run(**kwargs)

--- a/tests/test_cacheable_variable_ssm.py
+++ b/tests/test_cacheable_variable_ssm.py
@@ -1,0 +1,60 @@
+# pylint: skip-file
+# ruff: noqa
+
+from botocore.exceptions import ClientError
+from opentaskpy.exceptions import CachingPluginError
+
+from opentaskpy.variablecaching.aws import ssm
+from tests.fixtures.localstack import *  # noqa: F403
+
+
+def test_cacheable_variable_ssm_args():
+    # Test combinations of the plugin with invalid args
+    with pytest.raises(CachingPluginError):
+        ssm.run()
+
+    with pytest.raises(CachingPluginError):
+        ssm.run(name="/test/variable")
+
+    with pytest.raises(CachingPluginError):
+        ssm.run(value="newvalue")
+
+
+def test_cacheable_variable_ssm(ssm_client):
+
+    # Create a new ParamStore value
+    ssm_client.put_parameter(
+        Name="/test/variable",
+        Value="originalvalue",
+        Type="SecureString",
+        Overwrite=True,
+    )
+
+    param = ssm_client.get_parameter(Name="/test/variable", WithDecryption=True)
+
+    spec = {"task_id": "1234", "x": {"y": "value"}}
+
+    kwargs = {"name": f"/test/variable", "value": "newvalue"}
+
+    ssm.run(**kwargs)
+
+    # Check the variable has content of "newvalue"
+    assert (
+        ssm_client.get_parameter(Name="/test/variable", WithDecryption=True)[
+            "Parameter"
+        ]["Value"]
+        == "newvalue"
+    )
+
+
+def test_cacheable_variable_ssm_failure(ssm_client):
+
+    spec = {"task_id": "1234", "x": {"y": "value"}}
+
+    kwargs = {"name": f"xxxx", "value": "newvalue"}
+
+    # Remove the AWS_ENDPOINT_URL env var, so it tries to go to something that doesn't exist
+    del os.environ["AWS_ENDPOINT_URL"]
+
+    with pytest.raises(ClientError):
+        ssm.run(**kwargs)

--- a/tests/test_taskhandler_transfer_dummy_with_ssm_caching.py
+++ b/tests/test_taskhandler_transfer_dummy_with_ssm_caching.py
@@ -3,7 +3,7 @@
 
 from opentaskpy.taskhandlers import transfer
 
-from opentaskpy.variablecaching.aws import ssm
+from opentaskpy.variablecaching.aws import vc_ssm
 from tests.fixtures.localstack import *  # noqa: F403
 
 dummy_task_definition = {
@@ -15,7 +15,7 @@ dummy_task_definition = {
         "cacheableVariables": [
             {
                 "variableName": "accessToken",
-                "cachingPlugin": "aws.ssm",
+                "cachingPlugin": "aws.vc_ssm",
                 "cacheArgs": {
                     "name": "/test/variablename",
                 },


### PR DESCRIPTION
This pull request updates the opentaskpy dependency to version 24.22.0. It also includes other changes such as updating the python.testing.unittestArgs in devcontainer.json and adding a cacheable plugin and tweaking the SSM lookup plugin.