### PR TITLE
Add variable caching write using Secrets Manager

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -352,10 +352,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.2.0
+        uses: tarides/changelog-check-action@v2
         with:
-          fileName: CHANGELOG.md
+          changelog: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## v24.25.0
+
+- Added new cacheable plugin equivalent to the SSM one, but for Secrets Manager
+
 ## v24.23.0
 
-- Added new cacheable plugin to allow dynamically updated variables to be written back to SSM Parameter Store/Secrets Manager. For more detail see `open-task-framework` documentation for version 24.22.0
+- Added new cacheable plugin to allow dynamically updated variables to be written back to SSM Parameter Store. For more detail see `open-task-framework` documentation for version 24.22.0
 - Minor tweaks to SSM lookup plugin
 
 ## v24.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.23.0"
+version = "v24.25.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.23.0"
+current_version = "v24.25.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/plugins/lookup/aws/ssm.py
+++ b/src/opentaskpy/plugins/lookup/aws/ssm.py
@@ -76,7 +76,13 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
         response = ssm.get_parameter(Name=kwargs["name"], WithDecryption=True)
         result = response["Parameter"]["Value"]
 
-        logger.log(12, f"Read '{result}' from param {kwargs['name']}")
+        # Very simple redacting filter here for secrets, e.g. pgp private keys,
+        # or ssh private keys
+        log_result = result
+        if " private " in result.lower():
+            log_result = "REDACTED"
+
+        logger.log(12, f"Read '{log_result}' from param {kwargs['name']}")
 
     except ClientError as e:
         if e.response["Error"]["Code"] == "ParameterNotFound":

--- a/src/opentaskpy/variablecaching/aws/vc_secretsmanager.py
+++ b/src/opentaskpy/variablecaching/aws/vc_secretsmanager.py
@@ -1,0 +1,79 @@
+"""Caching plugin for writing variables to AWS Secrets Manager."""
+
+import os
+
+import boto3
+import opentaskpy.otflogging
+from botocore.exceptions import ClientError
+from opentaskpy.exceptions import CachingPluginError
+
+logger = opentaskpy.otflogging.init_logging(__name__)
+
+CACHE_NAME = "vc_secretsmanager"
+
+
+def run(**kwargs):  # type: ignore[no-untyped-def]
+    """Write a variable to AWS Secrets Manager.
+
+    Args:
+        **kwargs: Expect kwargs named 'name', and 'value'. This should be the Secrets
+         Manager secret to write to, and the value to put into the file
+
+    Raises:
+        CachingPluginError: Returned if the kwarg 'name' or 'value' is not provided
+        FileNotFoundError: Returned if the file does not exist
+    """
+    # Expect a kwarg named name, and value
+    expected_kwargs = ["name", "value"]
+    for kwarg in expected_kwargs:
+        if kwarg not in kwargs:
+            raise CachingPluginError(
+                f"Missing kwarg: '{kwarg}' while trying to run caching plugin"
+                f" '{CACHE_NAME}'"
+            )
+
+    globals_ = kwargs.get("globals", None)
+
+    aws_access_key_id = (
+        globals_["AWS_ACCESS_KEY_ID"]
+        if globals_ and "AWS_ACCESS_KEY_ID" in globals_
+        else os.environ.get("AWS_ACCESS_KEY_ID")
+    )
+    aws_secret_access_key = (
+        globals_["AWS_SECRET_ACCESS_KEY"]
+        if globals_ and "AWS_SECRET_ACCESS_KEY" in globals_
+        else os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+    region_name = (
+        globals_["AWS_REGION"]
+        if globals_ and "AWS_REGION" in globals_
+        else os.environ.get("AWS_REGION")
+    )
+    boto3_kwargs = {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+        "region_name": region_name,
+    }
+    # If there's an override for endpoint_url in the environment, then use that
+    kwargs2 = {}
+    if os.environ.get("AWS_ENDPOINT_URL"):
+        kwargs2["endpoint_url"] = os.environ.get("AWS_ENDPOINT_URL")
+
+    try:
+        session = boto3.session.Session(**boto3_kwargs)
+        secrets_manager = session.client("secretsmanager", **kwargs2)
+
+        # Write the value to secrets manager
+        secrets_manager.put_secret_value(
+            SecretId=kwargs["name"],
+            SecretString=kwargs["value"],
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.error(f"Secret not found: {kwargs['name']}: {e}")
+            raise e
+        raise e
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(f"Failed to write secret: {kwargs['name']}: {e}")
+        raise e

--- a/tests/fixtures/localstack.py
+++ b/tests/fixtures/localstack.py
@@ -114,3 +114,12 @@ def s3_client(localstack, credentials):
     }
     session = boto3.session.Session(**kwargs)
     return session.client("s3", endpoint_url=localstack)
+
+
+@pytest.fixture(scope="function")
+def secretsmanager_client(localstack, credentials):
+    kwargs = {
+        "region_name": "eu-west-1",
+    }
+    session = boto3.session.Session(**kwargs)
+    return session.client("secretsmanager", endpoint_url=localstack)

--- a/tests/test_cacheable_variable_secretsmanager.py
+++ b/tests/test_cacheable_variable_secretsmanager.py
@@ -26,8 +26,8 @@ def test_cacheable_variable_ssm_args():
 def test_cacheable_variable_vc_secretsmanager(secretsmanager_client):
 
     # Create a new ParamStore value
-    secretsmanager_client.put_parameter(
-        SecretId="/test/variable",
+    secretsmanager_client.create_secret(
+        Name="/test/variable",
         SecretString="originalvalue",
     )
 
@@ -52,7 +52,7 @@ def test_cacheable_variable_vc_secretsmanager(secretsmanager_client):
     )
 
 
-def test_cacheable_variable_secretsmanager_failure(ssm_client):
+def test_cacheable_variable_secretsmanager_failure(secretsmanager_client):
 
     kwargs = {"name": "xxxx", "value": "newvalue"}
 

--- a/tests/test_cacheable_variable_secretsmanager.py
+++ b/tests/test_cacheable_variable_secretsmanager.py
@@ -1,0 +1,63 @@
+# pylint: skip-file
+# ruff: noqa
+
+import os
+
+import pytest
+from botocore.exceptions import ClientError
+from opentaskpy.exceptions import CachingPluginError
+
+from opentaskpy.variablecaching.aws import vc_secretsmanager
+from tests.fixtures.localstack import *  # noqa: F403
+
+
+def test_cacheable_variable_ssm_args():
+    # Test combinations of the plugin with invalid args
+    with pytest.raises(CachingPluginError):
+        vc_secretsmanager.run()
+
+    with pytest.raises(CachingPluginError):
+        vc_secretsmanager.run(name="/test/variable")
+
+    with pytest.raises(CachingPluginError):
+        vc_secretsmanager.run(value="newvalue")
+
+
+def test_cacheable_variable_vc_secretsmanager(secretsmanager_client):
+
+    # Create a new ParamStore value
+    secretsmanager_client.put_parameter(
+        SecretId="/test/variable",
+        SecretString="originalvalue",
+    )
+
+    secretsmanager_client.get_secret_value(SecretId="/test/variable")
+
+    assert (
+        secretsmanager_client.get_secret_value(SecretId="/test/variable")[
+            "SecretString"
+        ]
+        == "originalvalue"
+    )
+
+    kwargs = {"name": "/test/variable", "value": "newvalue"}
+    vc_secretsmanager.run(**kwargs)
+
+    # Check the variable has content of "newvalue"
+    assert (
+        secretsmanager_client.get_secret_value(SecretId="/test/variable")[
+            "SecretString"
+        ]
+        == "newvalue"
+    )
+
+
+def test_cacheable_variable_secretsmanager_failure(ssm_client):
+
+    kwargs = {"name": "xxxx", "value": "newvalue"}
+
+    # Remove the AWS_ENDPOINT_URL env var, so it tries to go to something that doesn't exist
+    del os.environ["AWS_ENDPOINT_URL"]
+
+    with pytest.raises(ClientError):
+        vc_secretsmanager.run(**kwargs)

--- a/tests/test_cacheable_variable_ssm.py
+++ b/tests/test_cacheable_variable_ssm.py
@@ -1,6 +1,9 @@
 # pylint: skip-file
 # ruff: noqa
 
+import os
+
+import pytest
 from botocore.exceptions import ClientError
 from opentaskpy.exceptions import CachingPluginError
 


### PR DESCRIPTION
This pull request adds a new caching plugin that allows variables to be written to AWS Secrets Manager. The plugin provides a way to write values to Secrets Manager and supports dynamic updates. It also includes tests to ensure the functionality is working as expected.