### PR TITLE
JSON schema improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v24.25.2
+
+- Allow blank postCopyAction, or "none". This can be useful when using the same job definition for multiple environments and are using a variable to control the PCA. This way you can set the variable to "none" in the environment where you don't want it to run.
+- Also prevent S3 source directories from starting or ending with a /
+
 ## v24.25.1
 
 - Add possibility for encryption to the s3 schemas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.25.1"
+version = "v24.25.2"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.25.1"
+current_version = "v24.25.2"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source.json
@@ -8,7 +8,8 @@
     },
     "directory": {
       "type": "string",
-      "default": ""
+      "default": "",
+      "pattern": "^(?!/)(?!.*/$).*$"
     },
     "fileRegex": {
       "type": "string"

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/postCopyAction.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/postCopyAction.json
@@ -5,7 +5,7 @@
   "properties": {
     "action": {
       "type": "string",
-      "enum": ["move", "rename", "delete"]
+      "enum": ["move", "rename", "delete", "", "none"]
     },
     "destination": {
       "type": "string"
@@ -31,9 +31,16 @@
         "required": ["action", "destination"]
       },
       "else": {
-        "properties": {
-          "destination": {
-            "not": {}
+        "if": {
+          "properties": {
+            "action": {
+              "enum": ["move", "rename"]
+            }
+          }
+        },
+        "then": {
+          "not": {
+            "required": ["destination"]
           }
         }
       }

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -49,7 +49,7 @@ def valid_protocol_definition_using_assume_role_and_keys():
 def valid_transfer(valid_protocol_definition):
     return {
         "bucket": "test-bucket",
-        "directory": "/src",
+        "directory": "src",
         "fileRegex": ".*\\.txt",
         "protocol": valid_protocol_definition,
     }
@@ -98,6 +98,16 @@ def test_s3_source_basic(valid_transfer):
     }
 
     assert validate_transfer_json(json_data)
+
+    # Add / to the directory and validate it fails
+    json_data["source"]["directory"] = "/src/"
+    assert not validate_transfer_json(json_data)
+
+    json_data["source"]["directory"] = "/src"
+    assert not validate_transfer_json(json_data)
+
+    json_data["source"]["directory"] = "src/"
+    assert not validate_transfer_json(json_data)
 
     # Remove protocol
     del json_data["source"]["protocol"]
@@ -160,6 +170,22 @@ def test_s3_post_copy_action(valid_transfer):
 
     json_data["source"]["postCopyAction"]["destination"] = "/"
     assert validate_transfer_json(json_data)
+
+    json_data["source"]["postCopyAction"] = {
+        "action": "",
+    }
+    assert validate_transfer_json(json_data)
+
+    json_data["source"]["postCopyAction"] = {
+        "action": "none",
+        "destination": "s3://test-bucket/dest",
+    }
+    assert validate_transfer_json(json_data)
+
+    json_data["source"]["postCopyAction"] = {
+        "action": "invalid",
+    }
+    assert not validate_transfer_json(json_data)
 
 
 def test_s3_destination(valid_transfer, valid_destination):


### PR DESCRIPTION
This pull request includes improvements to the JSON schema. It allows for a blank postCopyAction or "none" value, which can be useful when using the same job definition for multiple environments. It also prevents S3 source directories from starting or ending with a "/".