### PR TITLE
Update botocore read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.28.0
+
+- Update Lambda protocol to allow overriding default `read_timeout¦ value from 60 seconds. This is needed when executing long running Lambda functions
+
 ## v24.25.2
 
 - Allow blank postCopyAction, or "none". This can be useful when using the same job definition for multiple environments and are using a variable to control the PCA. This way you can set the variable to "none" in the environment where you don't want it to run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.25.2"
+version = "v24.28.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.25.2"
+current_version = "v24.28.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/lambda/protocol.json
@@ -18,6 +18,9 @@
     },
     "region_name": {
       "type": "string"
+    },
+    "botocoreReadTimeout": {
+      "type": "int"
     }
   },
   "required": ["name"],

--- a/tests/test_remotehandler_lambda_execution.py
+++ b/tests/test_remotehandler_lambda_execution.py
@@ -214,6 +214,13 @@ def test_run_lambda_function(credentials, lambda_client, s3_client, setup_bucket
     )
     assert execution_obj.run()
 
+    # Change the protocol config to have a botocoreReadTimeout set
+    lambda_execution_task_definition_copy["protocol"]["botocoreReadTimeout"] = 10
+    execution_obj = execution.Execution(
+        None, "call-lambda-function", lambda_execution_task_definition_copy
+    )
+    assert execution_obj.run()
+
 
 def test_run_lambda_function_with_failure(credentials, lambda_client):
     function_arn = create_lambda_function(lambda_client, "lambda_failure.py", {})


### PR DESCRIPTION
This pull request updates the `get_aws_client` function in `creds.py` to include a `config` parameter that allows overriding the default `read_timeout` value.

This can be set in the protocol definition using botocoreReadTimeout property