### PR TITLE
Add aggressive keep-alives for long running lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.29.0
+
+- Add workaround for botocore issue with socket options for Lambda
+
 ## v24.28.1
 
 - Fix error in JSON schema for Lambda protocol

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.28.1"
+version = "v24.29.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.28.1"
+current_version = "v24.29.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/lambda.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/lambda.py
@@ -86,6 +86,7 @@ class LambdaExecution(RemoteExecutionHandler):
             if "botocoreReadTimeout" in self.spec["protocol"]:
                 config = Config(
                     read_timeout=self.spec["protocol"]["botocoreReadTimeout"],
+                    tcp_keepalive=True,
                 )
 
             client_result = get_aws_client(


### PR DESCRIPTION
Workaround issues where long running Lambda functions can timeout when invoked synchronously from AWS where the default NAT gateways have low connection timeouts set. This PR applys a monkey patch to botocore to force specific TCP socket settings to ensure frequent enough keep alives are sent to keep the connection open while waiting for Lambda to return a result.