### PR TITLE
Fix: Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.44.0
+
+- Alter logging messages for lambda and s3 transfers a little
+
 # v24.40.1
 
 - Bump workflow action versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v24.40.1"
+version = "v24.44.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -53,7 +53,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.40.1"
+current_version = "v24.44.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/aws/remotehandlers/lambda.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/lambda.py
@@ -137,9 +137,9 @@ class LambdaExecution(RemoteExecutionHandler):
                 Payload=json.dumps(payload),
             )
 
-            self.logger.debug(f"Got status code: {invoke_response['StatusCode']}")
+            self.logger.info(f"Got status code: {invoke_response['StatusCode']}")
             # Print the response
-            self.logger.debug(f"Lambda function response: {invoke_response}")
+            self.logger.info(f"Lambda function response: {invoke_response}")
 
             # Print the response payload
             self.logger.info(

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -231,7 +231,7 @@ class S3Transfer(RemoteTransferHandler):
 
         self.logger.info(
             f"Listing files in {self.spec['bucket']} matching"
-            f" {file_pattern}{' in' + (directory or '')}"
+            f" {file_pattern}{' in ' + (directory or '<Bucket Root directory>')}"
         )
 
         try:  # pylint: disable=too-many-nested-blocks


### PR DESCRIPTION
### Logging Improvements:
* [`src/opentaskpy/addons/aws/remotehandlers/lambda.py`](diffhunk://#diff-f8b13cb690faab1805d4c86a0744ca9c265388918183c6af1e385443ee580f47L140-R142): Changed logging level from `debug` to `info` for lambda function status and response messages.
* [`src/opentaskpy/addons/aws/remotehandlers/s3.py`](diffhunk://#diff-99dd033a6a4d8da7b38c051e9f9d1c388be030667e43dbc68dd1322b20b54915L234-R234): Modified logging message for listing files in S3 to handle cases where the directory is not specified.