### PR TITLE
feat: Add secrets manager lookup plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -340,7 +340,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -U .
-          python -m pytest --cov="opentaskpy.addons.aws" --cov="opentaskpy.plugins.aws" --cov-report=xml
+          python -m pytest --cov="opentaskpy.addons.aws" --cov="opentaskpy.plugins.aws" --cov="opentaskpy.plugins.lookup.aws" --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ poetry.toml
 test/testFiles
 test/volume
 tests/volume
+.envrc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,9 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
-        args:
-          - --check
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
-  "python.defaultInterpreterPath": "/usr/local/bin/python",
+  // "python.defaultInterpreterPath": "/usr/local/bin/python",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestArgs": ["."],
   "python.analysis.typeCheckingMode": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v25.8.0
+
+- Add lookup plugin for AWS Secrets Manager
+- Add new environment variable to force failures if lookups fail - `OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR`
+
 # v25.4.0
 
 - Have lambda logs output to OTF logs prior to exiting when lambda returns a FunctionError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,11 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 keywords = ["automation", "task", "framework", "aws", "s3", "ssm", "otf"]
-dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.23.0"]
+dependencies = [
+    "boto3 >= 1.26",
+    "jsonpath-ng >= 1.7.0",
+    "opentaskpy >= v24.23.0",
+]
 description = "Addons for opentaskpy, giving it the ability to push/pull via AWS S3, and pull variables from AWS SSM Parameter Store."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +31,7 @@ dev = [
     "pytest-shell",
     "types-requests",
     "types-python-dateutil",
-    "black >= 24.1.1",
+    "black >= 25.1.0",
     "isort",
     "pytest",
     "bumpver",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v25.4.0"
+version = "v25.8.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -57,7 +57,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.4.0"
+current_version = "v25.8.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/plugins/lookup/aws/secrets_manager.py
+++ b/src/opentaskpy/plugins/lookup/aws/secrets_manager.py
@@ -1,0 +1,178 @@
+"""Secrets Manager lookup plugin.
+
+Uses boto3 to pull out a secret from AWS Secrets Manager
+This uses AWS authentication, either from the IAM role of the host,
+by using environment variables, or variables in variables.json file
+"""
+
+import json
+import os
+
+import boto3
+import opentaskpy.otflogging
+from botocore.exceptions import ClientError
+from jsonpath_ng import parse
+from opentaskpy.exceptions import LookupPluginError
+
+logger = opentaskpy.otflogging.init_logging(__name__)
+
+plugin_name = "secretsmanager"
+
+
+def run(**kwargs):  # type: ignore[no-untyped-def]
+    """Pull a secret from AWS Secrets Manager.
+
+    Args:
+        **kwargs: Expect a kwarg named name. This should be the secret name
+        to obtain. The value should be a string.
+          Optionally, a kwarg named value pointing at the JSON path, if the secret is to
+            be parsed as JSON. The value returned will be the value at the path. The
+            value should be a string.
+
+
+    Raises:
+        LookupPluginError: Returned if the kwarg 'name' is not provided, or if the JSONPath
+            returns a value of the wrong type
+        ClientError: Returned if anything fails during the lookup
+
+    Returns:
+        _type_: The value read from Parameter Store. If there is an issue obtaining the
+            value, then "LOOKUP_FAILED" is returned, instead of causing the whole task
+            to fail, unless the environment variable OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR
+            is set to 1.
+    """
+    # Expect a kwarg named name
+    expected_kwargs = ["name"]
+    for kwarg in expected_kwargs:
+        if kwarg not in kwargs:
+            raise LookupPluginError(
+                f"Missing kwarg: '{kwarg}' while trying to run lookup plugin"
+                f" '{plugin_name}'"
+            )
+
+    fail_on_exception = (
+        os.environ.get("OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR", "0") == "1"
+    )
+
+    globals_ = kwargs.get("globals", None)
+
+    aws_access_key_id = (
+        globals_["AWS_ACCESS_KEY_ID"]
+        if globals_ and "AWS_ACCESS_KEY_ID" in globals_
+        else os.environ.get("AWS_ACCESS_KEY_ID")
+    )
+    aws_secret_access_key = (
+        globals_["AWS_SECRET_ACCESS_KEY"]
+        if globals_ and "AWS_SECRET_ACCESS_KEY" in globals_
+        else os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+    region_name = (
+        globals_["AWS_REGION"]
+        if globals_ and "AWS_REGION" in globals_
+        else os.environ.get("AWS_REGION")
+    )
+    boto3_kwargs = {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+        "region_name": region_name,
+    }
+    # If there's an override for endpoint_url in the environment, then use that
+    kwargs2 = {}
+    if os.environ.get("AWS_ENDPOINT_URL"):
+        kwargs2["endpoint_url"] = os.environ.get("AWS_ENDPOINT_URL")
+
+    result = None
+    try:
+        session = boto3.session.Session(**boto3_kwargs)
+        secretsmanager = session.client("secretsmanager", **kwargs2)
+        response = secretsmanager.get_secret_value(SecretId=kwargs["name"])
+        result = response["SecretString"]
+
+        # Very simple redacting filter here for secrets, e.g. pgp private keys,
+        # or ssh private keys
+        log_result = result
+        if " private " in result.lower():
+            log_result = "REDACTED"
+
+        logger.log(12, f"Read '{log_result}' from param {kwargs['name']}")
+
+        # If requested to pull a value from the JSON, then parse it and extract the
+        # value at the path
+        if "value" in kwargs:
+            try:
+                result = json.loads(result)
+                # Handle the JSONPath
+                jsonpath_expr = parse(kwargs["value"])
+                result = jsonpath_expr.find(result)
+
+                result = result[0].value
+
+                # If the result is a list, then return the first element, with a warning
+                # that there's more than one
+                if isinstance(result, list) and isinstance(result[0], (str, int)):
+                    logger.warning(
+                        f"JSONPath returned a list of length {len(result)}. Returning "
+                        + "only the first element"
+                    )
+                    result = result[0]
+
+                # If the result is not a string or an int, then raise an exception
+                if not isinstance(result, (str, int)):
+                    if fail_on_exception:
+                        raise LookupPluginError(
+                            f"JSONPath returned a value of type {type(result)}. Expected a string or int"
+                        )
+                    logger.warning(
+                        f"JSONPath returned a value of type {type(result)}. Continuing anyway."
+                    )
+                    return "LOOKUP_FAILED"
+
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse JSON from secret: {kwargs['name']}: {e}")
+
+                if fail_on_exception:
+                    raise e
+
+                logger.warning("Secret JSON parsing failed but continuing anyway")
+                return "LOOKUP_FAILED"
+            except KeyError as e:
+                logger.error(f"Failed to read from secret: {kwargs['name']}: {e}")
+
+                if fail_on_exception:
+                    raise e
+
+                logger.warning("Secret JSON parsing failed but continuing anyway")
+                return "LOOKUP_FAILED"
+
+    except ClientError as e:
+        # To prevent complete failure of all jobs in an environment on failed lookup
+        # return 'LOOKUP_FAILED and log error instead of throwing exception'
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.error(f"Secret not found: {kwargs['name']}: {e}")
+        else:
+            logger.error(f"Failed to read from Secrets Manager: {kwargs['name']}: {e}")
+
+        if fail_on_exception:
+            raise e
+
+        logger.warning("Secrets Manager lookup failed but continuing anyway")
+        return "LOOKUP_FAILED"
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(f"Failed to read from Secrets Manager: {kwargs['name']}: {e}")
+
+        if fail_on_exception:
+            raise e
+
+        logger.warning("Secrets Manager lookup failed but continuing anyway")
+        return "LOOKUP_FAILED"
+
+    # Escape any escape characters so they can be stored in JSON as a string
+    if result and isinstance(result, str):
+        # Escape any newline characters
+        result = result.replace("\n", "\\n")
+        result = json.dumps(result)
+        # Remove the leading and trailing quotes
+        result = result[1:-1]
+
+    return result

--- a/tests/fixtures/localstack.py
+++ b/tests/fixtures/localstack.py
@@ -87,6 +87,8 @@ def cleanup_credentials():
         del os.environ["AWS_ENDPOINT_URL"]
     if os.environ.get("ASSUME_ROLE_ARN"):
         del os.environ["ASSUME_ROLE_ARN"]
+    if os.environ.get("OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"):
+        del os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"]
 
 
 @pytest.fixture(scope="function")
@@ -96,6 +98,15 @@ def ssm_client(localstack, credentials):
     }
     session = boto3.session.Session(**kwargs)
     return session.client("ssm", endpoint_url=localstack)
+
+
+@pytest.fixture(scope="function")
+def secrets_manager_client(localstack, credentials):
+    kwargs = {
+        "region_name": "eu-west-1",
+    }
+    session = boto3.session.Session(**kwargs)
+    return session.client("secretsmanager", endpoint_url=localstack)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_plugin_secrets_manager.py
+++ b/tests/test_plugin_secrets_manager.py
@@ -1,0 +1,259 @@
+# pylint: skip-file
+# ruff: noqa
+import json
+import logging
+from json.decoder import JSONDecodeError
+
+import opentaskpy.otflogging
+import pytest
+from botocore.exceptions import ClientError
+from opentaskpy.config.loader import ConfigLoader
+from opentaskpy.exceptions import LookupPluginError
+from pytest_shell import fs
+
+from opentaskpy.plugins.lookup.aws.secrets_manager import run
+from tests.fixtures.localstack import *  # noqa: F403
+
+PLUGIN_NAME = "secretsmanager"
+
+# Get the default logger and set it to DEBUG
+logger = logging.getLogger()
+logger.setLevel(12)
+
+
+def test_secrets_manager_plugin_missing_name():
+    with pytest.raises(Exception) as ex:
+        run()
+
+    assert (
+        ex.value.args[0]
+        == f"Missing kwarg: 'name' while trying to run lookup plugin '{PLUGIN_NAME}'"
+    )
+
+
+def test_secrets_manager_plugin_secret_not_found(credentials, caplog):
+    # Ensure lookups throw an exception when lookups fail
+
+    os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"] = "1"
+
+    with pytest.raises(ClientError) as ex:
+        result = run(name="does_not_exist")
+
+    # Ensure secrets lookup failures return "LOOKUP_FAILED" and log warning rather than raising an exception to prevent full environment failure,
+    # when OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR env var is not set
+
+    del os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"]
+
+    with caplog.at_level(logging.WARNING):
+        result = run(name="does_not_exist")
+    assert "Secrets Manager lookup failed but continuing anyway" in caplog.text
+    assert result == "LOOKUP_FAILED"
+
+
+def test_secrets_manager_plugin_standard_string(secrets_manager_client):
+    expected = "test1234"
+    # Populate a Secrets Manager secret with a test value
+    secrets_manager_client.create_secret(Name="standard_string", SecretString=expected)
+
+    result = run(name="standard_string")
+
+    assert result == expected
+
+
+def test_secrets_manager_plugin_redacted_secret(secrets_manager_client, caplog):
+    expected = " private "
+    # Populate a Secrets Manager secret with a test value
+    secrets_manager_client.create_secret(
+        Name="redacted_secret", SecretString=" private "
+    )
+
+    with caplog.at_level(12):
+        # Ensure the logger is set to the same VERBOSE level
+        opentaskpy.otflogging.init_logging(
+            "opentaskpy.plugins.lookup.aws.secrets_manager"
+        )
+        result = run(name="redacted_secret")
+    assert "Read 'REDACTED' from param redacted_secret" in caplog.text
+
+    assert result == expected
+
+
+def test_config_loader_using_secretsmanager_plugin(secrets_manager_client, tmpdir):
+    json_obj = {
+        "testLookup": "{{ lookup('aws.secrets_manager', name='standard_string_multiline') }}",
+    }
+
+    fs.create_files(
+        [
+            {
+                f"{tmpdir}/variables.json.j2": {
+                    "content": json.dumps(json_obj),
+                }
+            },
+        ]
+    )
+    # Test with a multi line string to make sure that it doesn't break the parser
+    expected_result = """config_loader_test_1234\\nanother_line"""
+
+    # Insert the param into secrets manager
+    secrets_manager_client.create_secret(
+        Name="standard_string_multiline", SecretString=expected_result
+    )
+
+    # Test that the global variables are loaded correctly
+    config_loader = ConfigLoader(tmpdir)
+    config_loader._load_global_variables()
+    config_loader._resolve_templated_variables()
+
+    assert config_loader.get_global_variables()["testLookup"] == expected_result
+
+
+def test_config_loader_using_secretsmanager_plugin_json_path(
+    secrets_manager_client, tmpdir
+):
+    json_obj = {
+        "testLookup": "{{ lookup('aws.secrets_manager', name='plugin_json_path', value='foo.bar.[1]') }}",
+    }
+
+    fs.create_files(
+        [
+            {
+                f"{tmpdir}/variables.json.j2": {
+                    "content": json.dumps(json_obj),
+                }
+            },
+        ]
+    )
+    # Test with a multi line string to make sure that it doesn't break the parser
+    expected_result = "nested_secret_value"
+
+    # Insert the param into paramstore
+    secrets_manager_client.create_secret(
+        Name="plugin_json_path",
+        SecretString=json.dumps(
+            {"foo": {"bar": ["first_secret_value", "nested_secret_value"]}}
+        ),
+    )
+
+    # Test that the global variables are loaded correctly
+    config_loader = ConfigLoader(tmpdir)
+    config_loader._load_global_variables()
+    config_loader._resolve_templated_variables()
+
+    assert config_loader.get_global_variables()["testLookup"] == expected_result
+
+
+def test_config_loader_using_secretsmanager_plugin_invalid_return_types(
+    secrets_manager_client, tmpdir, caplog
+):
+    # Insert the param into paramstore
+    secrets_manager_client.create_secret(
+        Name="invalid_return_types",
+        SecretString=json.dumps(
+            {"foo": {"bar": ["first_secret_value", "nested_secret_value"]}}
+        ),
+    )
+
+    json_obj = {
+        "testLookup": "{{ lookup('aws.secrets_manager', name='invalid_return_types', value='foo') }}",
+    }
+
+    fs.create_files(
+        [
+            {
+                f"{tmpdir}/variables.json.j2": {
+                    "content": json.dumps(json_obj),
+                }
+            },
+        ]
+    )
+    # Test that the global variables are loaded correctly
+    with caplog.at_level(logging.WARNING):
+        config_loader = ConfigLoader(tmpdir)
+        config_loader._load_global_variables()
+        config_loader._resolve_templated_variables()
+
+    assert (
+        "JSONPath returned a value of type <class 'dict'>. Continuing anyway."
+        in caplog.text
+    )
+    assert config_loader.get_global_variables()["testLookup"] == "LOOKUP_FAILED"
+
+    # Run again but with exceptions being raised
+    os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"] = "1"
+    with pytest.raises(LookupPluginError) as ex:
+        config_loader = ConfigLoader(tmpdir)
+        config_loader._load_global_variables()
+        config_loader._resolve_templated_variables()
+
+    del os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"]
+
+    # Delete the previous variables file
+    os.remove(f"{tmpdir}/variables.json.j2")
+
+    # Now do a list
+    json_obj = {
+        "testLookup": "{{ lookup('aws.secrets_manager', name='invalid_return_types', value='foo.bar') }}",
+    }
+    fs.create_files(
+        [
+            {
+                f"{tmpdir}/variables.json.j2": {
+                    "content": json.dumps(json_obj),
+                }
+            },
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        config_loader = ConfigLoader(tmpdir)
+        config_loader._load_global_variables()
+        config_loader._resolve_templated_variables()
+
+    assert (
+        "JSONPath returned a list of length 2. Returning only the first element"
+        in caplog.text
+    )
+    assert config_loader.get_global_variables()["testLookup"] == "first_secret_value"
+
+
+def test_config_loader_using_secretsmanager_plugin_invalid_json(
+    secrets_manager_client, tmpdir, caplog
+):
+    # Insert the param into paramstore
+    secrets_manager_client.create_secret(
+        Name="invalid_return_json",
+        SecretString=json.dumps(
+            {"foo": {"bar": ["first_secret_value", "nested_secret_value"]}}
+        )
+        + "}}}}",  # Intentionally break the JSON
+    )
+
+    json_obj = {
+        "testLookup": "{{ lookup('aws.secrets_manager', name='invalid_return_json', value='foo') }}",
+    }
+
+    fs.create_files(
+        [
+            {
+                f"{tmpdir}/variables.json.j2": {
+                    "content": json.dumps(json_obj),
+                }
+            },
+        ]
+    )
+    # Test that the global variables are loaded correctly
+    with caplog.at_level(logging.WARNING):
+        config_loader = ConfigLoader(tmpdir)
+        config_loader._load_global_variables()
+        config_loader._resolve_templated_variables()
+
+    assert "Secret JSON parsing failed but continuing anyway" in caplog.text
+    assert config_loader.get_global_variables()["testLookup"] == "LOOKUP_FAILED"
+
+    # Run again but with exceptions being raised
+    os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"] = "1"
+    with pytest.raises(JSONDecodeError) as ex:
+        config_loader = ConfigLoader(tmpdir)
+        config_loader._load_global_variables()
+        config_loader._resolve_templated_variables()

--- a/tests/test_plugin_ssm.py
+++ b/tests/test_plugin_ssm.py
@@ -29,11 +29,19 @@ def test_ssm_plugin_missing_name():
 
 
 def test_ssm_plugin_param_name_not_found(credentials, caplog):
-    # Ensure parameter lookup failures return "UNKNOWN" and log warning rather than raising an exception to prevent full environment failure
+    os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"] = "1"
+
+    with pytest.raises(ClientError) as ex:
+        result = run(name="does_not_exist")
+
+    del os.environ["OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR"]
+
+    # Ensure parameter lookup failures return "LOOKUP_FAILED" and log warning rather than raising an exception to prevent full environment failure,
+    # when OTF_AWS_SECRETS_LOOKUP_FAILED_IS_ERROR env var is not set
     with caplog.at_level(logging.WARNING):
         result = run(name="does_not_exist")
     assert "SSM parameter lookup failed but continuing anyway" in caplog.text
-    assert result == "UNKNOWN"
+    assert result == "LOOKUP_FAILED"
 
 
 def test_ssm_plugin_standard_string(ssm_client):


### PR DESCRIPTION
Adds support for AWS Secrets Manager. Additionally, it includes updates to dependencies, configurations, and tests to accommodate this new feature. The most important changes are summarized below:

### New Feature: AWS Secrets Manager Plugin
* Added a new plugin for AWS Secrets Manager to pull dynamic variables, including support for JSONPath expressions. (`README.md`, `src/opentaskpy/plugins/lookup/aws/secrets_manager.py`, `tests/test_plugin_secrets_manager.py`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-318f8a2da8e501c2b83502c9577ea0c54c080f52a96f15bf79c3edf402042940R1-R178) [[3]](diffhunk://#diff-d8488237a4bd1ec4d2aa7cc90b3a2d4ba25a882fcbaf7b7ce204d2fe8c35792fR1-R259)

### Configuration and Dependency Updates
* Updated `pyproject.toml` to include `jsonpath-ng` as a new dependency required for the AWS Secrets Manager plugin. (`pyproject.toml`)
* Updated the version of `black` from `24.1.1` to `25.1.0` in both `pyproject.toml` and `.pre-commit-config.yaml`. (`pyproject.toml`, `.pre-commit-config.yaml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-R34) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L35-L39)

### Test and Workflow Enhancements
* Modified the test workflow to include coverage for the new AWS Secrets Manager plugin. (`.github/workflows/test.yml`)
* Added new fixtures and tests for the AWS Secrets Manager plugin to ensure its functionality and robustness. (`tests/fixtures/localstack.py`, `tests/test_plugin_secrets_manager.py`) [[1]](diffhunk://#diff-77953b42e8490db78f76ccb312d221ba985a4453376c4ba680d81c8175d41202R103-R111) [[2]](diffhunk://#diff-d8488237a4bd1ec4d2aa7cc90b3a2d4ba25a882fcbaf7b7ce204d2fe8c35792fR1-R259)

### Minor Changes and Fixes
* Updated the `ssm` plugin to handle lookup failures consistently with the new `secrets_manager` plugin. (`src/opentaskpy/plugins/lookup/aws/ssm.py`) [[1]](diffhunk://#diff-5fe13a1380927f3276d574b735555a3337f0934f84ed7a67adb40a818daf6e01R44-R47) [[2]](diffhunk://#diff-5fe13a1380927f3276d574b735555a3337f0934f84ed7a67adb40a818daf6e01L88-R110)