### PR TITLE
Add ability to override default assumed role token expiry time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v25.27.1
+
+- Allow specifying a long token expiry time for assumed role credentials. This is useful for long running transfers, such as multipart uploads, where the token may expire before the transfer is complete.
+
 # v25.27.0
 
 - Updates the Schema for ecsFargate remotehandler to allow specifying which container to apply containerOverides to, as well as the container for which to check the exit code to determine task success/failure

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Credentials can be set via config using equivalently named variables alongside t
 
 If the standard AWS environment variables are set, then these will be used if not set elsewhere. Otherwise, if running from AWS, then the IAM role of the machine running OTF will be used.
 
+If you are using an assumed role, the temporary credentials default to a 15 minute expiry time. This can be overridden by setting the `token_expiry_seconds` attribute in the protocol definition. The min and max values for this match the AWS STS values detailed [here](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+
 # Other Environment Variables
 
 The following environment variables can be set to override the default behaviour of the AWS remote handlers:

--- a/src/opentaskpy/addons/aws/remotehandlers/ecsfargate.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/ecsfargate.py
@@ -35,6 +35,7 @@ class FargateTaskExecution(RemoteExecutionHandler):
         self.aws_secret_access_key: str | None = None
         self.region_name: str | None = None
         self.temporary_creds: dict | None = None
+        self.token_expiry_seconds: int | None = None
         self.assume_role_arn: str | None
         self.ecs_client: boto3.Client = None
 
@@ -70,7 +71,10 @@ class FargateTaskExecution(RemoteExecutionHandler):
                 self.logger.info("Renewing temporary credentials")
 
             client_result = get_aws_client(
-                "ecs", self.credentials, self.assume_role_arn
+                "ecs",
+                credentials=self.credentials,
+                token_expiry_seconds=self.token_expiry_seconds,
+                assume_role_arn=self.assume_role_arn,
             )
             self.temporary_creds = (
                 client_result["temporary_creds"]
@@ -363,7 +367,9 @@ class FargateTaskExecution(RemoteExecutionHandler):
                     logstream_name = f"{container_name}/{self.fargate_task_id}"
                 # Get the log events
                 log_events = get_aws_client(
-                    "logs", self.credentials, self.assume_role_arn
+                    "logs",
+                    credentials=self.credentials,
+                    assume_role_arn=self.assume_role_arn,
                 )["client"].get_log_events(
                     logGroupName=self.spec["cloudwatchLogGroupName"],
                     logStreamName=logstream_name,

--- a/src/opentaskpy/addons/aws/remotehandlers/lambda.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/lambda.py
@@ -103,7 +103,10 @@ class LambdaExecution(RemoteExecutionHandler):
             config = Config(**config_options)
 
             client_result = get_aws_client(
-                "lambda", self.credentials, self.assume_role_arn, config=config
+                "lambda",
+                self.credentials,
+                assume_role_arn=self.assume_role_arn,
+                config=config,
             )
             self.temporary_creds = (
                 client_result["temporary_creds"]

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -38,6 +38,7 @@ class S3Transfer(RemoteTransferHandler):
         self.aws_secret_access_key: str | None = None
         self.region_name: str | None = None
         self.temporary_creds: dict | None = None
+        self.token_expiry_seconds: int | None = None
         self.assume_role_arn: str | None
         self.s3_client: boto3.Client = None
 
@@ -72,7 +73,12 @@ class S3Transfer(RemoteTransferHandler):
             if self.temporary_creds:
                 self.logger.info("Renewing temporary credentials")
 
-            client_result = get_aws_client("s3", self.credentials, self.assume_role_arn)
+            client_result = get_aws_client(
+                "s3",
+                self.credentials,
+                token_expiry_seconds=self.token_expiry_seconds,
+                assume_role_arn=self.assume_role_arn,
+            )
             self.temporary_creds = (
                 client_result["temporary_creds"]
                 if client_result["temporary_creds"]
@@ -540,7 +546,9 @@ class S3Execution(RemoteExecutionHandler):
             if self.temporary_creds:
                 self.logger.info("Renewing temporary credentials")
 
-            client_result = get_aws_client("s3", self.credentials, self.assume_role_arn)
+            client_result = get_aws_client(
+                "s3", self.credentials, assume_role_arn=self.assume_role_arn
+            )
             self.temporary_creds = (
                 client_result["temporary_creds"]
                 if client_result["temporary_creds"]

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/execution/ecsfargate/protocol.json
@@ -15,6 +15,12 @@
     "secret_access_key": {
       "type": "string"
     },
+    "token_expiry_seconds": {
+      "type": "integer",
+      "minimum": 900,
+      "maximum": 43200,
+      "default": 900
+    },
     "assume_role_arn": {
       "type": "string"
     },
@@ -37,6 +43,14 @@
           "secret_access_key": { "type": "string" }
         },
         "required": ["secret_access_key"]
+      }
+    },
+    {
+      "if": {
+        "required": ["token_expiry_seconds"]
+      },
+      "then": {
+        "required": ["assume_role_arn"]
       }
     }
   ]

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
@@ -16,6 +16,12 @@
     "assume_role_arn": {
       "type": "string"
     },
+    "token_expiry_seconds": {
+      "type": "integer",
+      "minimum": 900,
+      "maximum": 43200,
+      "default": 900
+    },
     "region_name": {
       "type": "string"
     }
@@ -35,6 +41,14 @@
           "secret_access_key": { "type": "string" }
         },
         "required": ["secret_access_key"]
+      }
+    },
+    {
+      "if": {
+        "required": ["token_expiry_seconds"]
+      },
+      "then": {
+        "required": ["assume_role_arn"]
       }
     }
   ]

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
@@ -16,6 +16,12 @@
     "assume_role_arn": {
       "type": "string"
     },
+    "token_expiry_seconds": {
+      "type": "integer",
+      "minimum": 900,
+      "maximum": 43200,
+      "default": 900
+    },
     "region_name": {
       "type": "string"
     }
@@ -35,6 +41,14 @@
           "secret_access_key": { "type": "string" }
         },
         "required": ["secret_access_key"]
+      }
+    },
+    {
+      "if": {
+        "required": ["token_expiry_seconds"]
+      },
+      "then": {
+        "required": ["assume_role_arn"]
       }
     }
   ]

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -836,12 +836,12 @@ def test_local_to_s3_assume_role_expiry_long_token_expiry(
     # Add the log capture handler to the logger
     logger.addHandler(LogCaptureHandler())
 
-    # Check for alog message like
+    # Check for a log message like
     # 2025-07-12 14:35:56,185 botocore.endpoint [DEBUG] Making request for OperationModel(name=AssumeRole) with params: {'url_path': '/', 'query_string': '', 'method': 'POST', 'headers': {'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8', 'User-Agent': 'Boto3/1.39.4 md/Botocore#1.39.4 ua/2.1 os/linux#6.6.12-linuxkit md/arch#aarch64 lang/python#3.11.11 md/pyimpl#CPython m/Z,D,b cfg/retry-mode#legacy Botocore/1.39.4'}, 'body': {'Action': 'AssumeRole', 'Version': '2011-06-15', 'RoleArn': 'arn:aws:iam::133141744297:role/assumed-role-otf-addons-aws-dev', 'RoleSessionName': 'OTF1752330956.1843534', 'DurationSeconds': 900}, 'url': 'https://sts.amazonaws.com/', 'context': {'client_region': 'eu-west-1', 'client_config': <botocore.config.Config object at 0xffff8f26fb50>, 'has_streaming_input': False, 'auth_type': 'v4', 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4'], 'signing': {'region': 'us-east-1', 'signing_name': 'sts'}, 'endpoint_properties': {'authSchemes': [{'name': 'sigv4', 'signingName': 'sts', 'signingRegion': 'us-east-1'}]}}}
 
     # Run the transfer
     assert transfer_obj.run()
-    # Check the log messages for the STS request asking for the session of length 1234 seconds, regex matching agains 'DurationSeconds': 1234
+    # Check the log messages for the STS request asking for the session of length 1234 seconds, regex matching against 'DurationSeconds': 1234
     found_duration = False
     for log_message in log_messages:
         if re.search(r"'DurationSeconds': 1234", log_message):

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -92,7 +92,7 @@ def test_s3_source_protocol(
 
     json_data["source"]["protocol"] = valid_protocol_definition_using_assume_role
 
-    # Set the expiry to a sensible valule
+    # Set the expiry to a sensible value
     json_data["source"]["protocol"]["token_expiry_seconds"] = 10000
     assert validate_transfer_json(json_data)
 

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -90,6 +90,23 @@ def test_s3_source_protocol(
     json_data["source"]["protocol"] = invalid_protocol_definition_using_keys_no_secret
     assert not validate_transfer_json(json_data)
 
+    json_data["source"]["protocol"] = valid_protocol_definition_using_assume_role
+
+    # Set the expiry to a sensible valule
+    json_data["source"]["protocol"]["token_expiry_seconds"] = 10000
+    assert validate_transfer_json(json_data)
+
+    # Set it too low, and too high
+    json_data["source"]["protocol"]["token_expiry_seconds"] = 899
+    assert not validate_transfer_json(json_data)
+
+    json_data["source"]["protocol"]["token_expiry_seconds"] = 43201
+    assert not validate_transfer_json(json_data)
+
+    # Remove the assume role arn and validate it fails
+    del json_data["source"]["protocol"]["assume_role_arn"]
+    assert not validate_transfer_json(json_data)
+
 
 def test_s3_source_basic(valid_transfer):
     json_data = {


### PR DESCRIPTION
Allow custom timeout for assumed role temporary creds. When running long file uploads the default 15 min token might expire, which is unrecoverable, so a longer token timeout needs to be specified