### PR TITLE
Add timeouts for botocore & fix exception when calling tidy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ env:
   DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   KEY_PREFIX: base-venv
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 # yamllint disable-line rule:truthy
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v26.28.0
+
+- Add support for specifying botore timeouts and retries for s3 transfers/executions
+- Fix issue in tidy throwing an exception when the s3 client was already closed
+
 # v26.18.0
 
 - Fix a bug where the S3 client was not being properly closed and garbage collected, which could lead to resource leaks and issues with too many open connections. This was caused by the `tidy` method not setting the `s3_client` attribute to `None` after closing it, which meant that the botocore objects were not being garbage collected.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ JSON configs for transfers can be defined as follows:
 ]
 ```
 
+### Default S3 client timeout behaviour
+
+S3 transfers now apply botocore defaults even when not specified in the protocol:
+
+- `botocoreReadTimeout`: `60`
+- `botocoreConnectTimeout`: `10`
+- `max_attempts`: `0`
+
+These are socket/connect and retry settings, not a total transfer deadline. A large
+upload or download that is still making progress can continue past the batch timeout
+request and still complete successfully. The defaults mainly prevent stalled S3 calls
+from sitting in botocore retries for longer than necessary. All three values can still
+be overridden per protocol when needed.
+
 ## Example S3 upload with flag files
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-aws"
-version = "v26.18.0"
+version = "v26.28.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -57,7 +57,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.18.0"
+current_version = "v26.28.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 keywords = ["automation", "task", "framework", "aws", "s3", "ssm", "otf"]
 dependencies = [
-    "boto3 >= 1.26",
+    "boto3 >= 1.43",
     "jsonpath-ng >= 1.7.0",
     "opentaskpy >= v26.18.1",
 ]
@@ -373,8 +373,6 @@ ignore = [
     "D407", # Section name underlining
     "E501", # line too long
     "E731", # do not assign a lambda expression, use a def
-    # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
-    "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [
-    "awscli",
-    "awscli-local",
+    "awscli >= 1.45.51",
+    "awscli-local >= 0.22.2",
     "pytest-shell",
     "types-requests",
     "types-python-dateutil",

--- a/src/opentaskpy/addons/aws/remotehandlers/creds.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/creds.py
@@ -96,6 +96,8 @@ def get_aws_client(  # pylint: disable=too-many-positional-arguments
     kwargs = {}
     if os.environ.get("AWS_ENDPOINT_URL"):
         kwargs["endpoint_url"] = os.environ.get("AWS_ENDPOINT_URL")
+    if credentials.get("region_name"):
+        kwargs["region_name"] = credentials["region_name"]
 
     if assume_role_arn:
         logger.info(f"Assuming role: {assume_role_arn}")

--- a/src/opentaskpy/addons/aws/remotehandlers/s3.py
+++ b/src/opentaskpy/addons/aws/remotehandlers/s3.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 import boto3
 import opentaskpy.otflogging
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from dateutil.tz import tzlocal
 from opentaskpy.remotehandlers.remotehandler import (
@@ -17,6 +18,32 @@ from opentaskpy.remotehandlers.remotehandler import (
 from .creds import get_aws_client, set_aws_creds
 
 MAX_OBJECTS_PER_QUERY = 100
+DEFAULT_S3_BOTOCORE_READ_TIMEOUT = 60
+DEFAULT_S3_BOTOCORE_CONNECT_TIMEOUT = 10
+DEFAULT_S3_BOTOCORE_MAX_ATTEMPTS = 0
+
+
+def _build_botocore_config(protocol: dict) -> Config:
+    """Build a botocore client config from the task protocol settings.
+
+    Defaults are applied so S3 transfers do not inherit botocore retry behaviour that
+    can keep a batch blocked longer than expected after a timeout request.
+    """
+    config_options = {
+        "read_timeout": protocol.get(
+            "botocoreReadTimeout", DEFAULT_S3_BOTOCORE_READ_TIMEOUT
+        ),
+        "connect_timeout": protocol.get(
+            "botocoreConnectTimeout", DEFAULT_S3_BOTOCORE_CONNECT_TIMEOUT
+        ),
+        "retries": {
+            "max_attempts": protocol.get(
+                "max_attempts", DEFAULT_S3_BOTOCORE_MAX_ATTEMPTS
+            )
+        },
+    }
+
+    return Config(**config_options)
 
 
 class S3Transfer(RemoteTransferHandler):
@@ -74,12 +101,15 @@ class S3Transfer(RemoteTransferHandler):
             if self.temporary_creds:
                 self.logger.info("Renewing temporary credentials")
 
+            client_config = _build_botocore_config(self.spec["protocol"])
+
             client_result = get_aws_client(
                 "s3",
                 self.credentials,
                 token_expiry_seconds=self.token_expiry_seconds,
                 assume_role_arn=self.assume_role_arn,
                 assume_role_external_id=self.assume_role_external_id,
+                config=client_config,
             )
             self.temporary_creds = (
                 client_result["temporary_creds"]
@@ -484,7 +514,8 @@ class S3Transfer(RemoteTransferHandler):
 
     def tidy(self) -> None:
         """Tidy up the S3 client."""
-        self.s3_client.close()
+        if self.s3_client and hasattr(self.s3_client, "close"):
+            self.s3_client.close()
         self.s3_client = None  # allow botocore objects to be garbage collected
 
 
@@ -593,5 +624,6 @@ class S3Execution(RemoteExecutionHandler):
 
     def tidy(self) -> None:
         """Tidy up the S3 client."""
-        self.s3_client.close()
+        if self.s3_client and hasattr(self.s3_client, "close"):
+            self.s3_client.close()
         self.s3_client = None  # allow botocore objects to be garbage collected

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_destination/protocol.json
@@ -27,6 +27,15 @@
     },
     "region_name": {
       "type": "string"
+    },
+    "botocoreReadTimeout": {
+      "type": "integer"
+    },
+    "botocoreConnectTimeout": {
+      "type": "integer"
+    },
+    "max_attempts": {
+      "type": "integer"
     }
   },
   "required": ["name"],

--- a/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
+++ b/src/opentaskpy/addons/aws/remotehandlers/schemas/transfer/s3_source/protocol.json
@@ -27,6 +27,15 @@
     },
     "region_name": {
       "type": "string"
+    },
+    "botocoreReadTimeout": {
+      "type": "integer"
+    },
+    "botocoreConnectTimeout": {
+      "type": "integer"
+    },
+    "max_attempts": {
+      "type": "integer"
     }
   },
   "required": ["name"],

--- a/src/opentaskpy/plugins/lookup/aws/secrets_manager.py
+++ b/src/opentaskpy/plugins/lookup/aws/secrets_manager.py
@@ -110,7 +110,7 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
 
                 # If the result is a list, then return the first element, with a warning
                 # that there's more than one
-                if isinstance(result, list) and isinstance(result[0], (str, int)):
+                if isinstance(result, list) and isinstance(result[0], str | int):
                     logger.warning(
                         f"JSONPath returned a list of length {len(result)}. Returning "
                         + "only the first element"
@@ -118,7 +118,7 @@ def run(**kwargs):  # type: ignore[no-untyped-def]
                     result = result[0]
 
                 # If the result is not a string or an int, then raise an exception
-                if not isinstance(result, (str, int)):
+                if not isinstance(result, str | int):
                     if fail_on_exception:
                         raise LookupPluginError(
                             f"JSONPath returned a value of type {type(result)}. Expected a string or int"

--- a/tests/fixtures/localstack.py
+++ b/tests/fixtures/localstack.py
@@ -53,6 +53,7 @@ def credentials(floci, cleanup_credentials):
     os.environ["AWS_ACCESS_KEY_ID"] = "test"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
     os.environ["AWS_REGION"] = "eu-west-1"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
     os.environ["AWS_ENDPOINT_URL"] = floci
 
 
@@ -64,6 +65,8 @@ def cleanup_credentials():
         del os.environ["AWS_SECRET_ACCESS_KEY"]
     if os.environ.get("AWS_REGION"):
         del os.environ["AWS_REGION"]
+    if os.environ.get("AWS_DEFAULT_REGION"):
+        del os.environ["AWS_DEFAULT_REGION"]
     if os.environ.get("AWS_ENDPOINT_URL"):
         del os.environ["AWS_ENDPOINT_URL"]
     if os.environ.get("ASSUME_ROLE_ARN"):

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -313,7 +313,7 @@ s3_to_s3_assume_role_task_definition = {
         },
         "protocol": {
             "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
-            "assume_role_arn": "arn:aws:iam::012345678900:role/dummy-role",
+            "assume_role_arn": "arn:aws:iam::000000000000:role/dummy-role",
         },
     },
     "destination": [

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -17,6 +17,7 @@ from opentaskpy.taskhandlers import transfer
 from pytest_shell import fs
 
 from opentaskpy import exceptions
+from opentaskpy.addons.aws.remotehandlers.creds import get_aws_client
 from opentaskpy.addons.aws.remotehandlers.s3 import S3Transfer
 from tests.fixtures.localstack import *
 
@@ -609,6 +610,66 @@ def test_s3_transfer_tidy_is_idempotent(monkeypatch):
 
     assert client.close_calls == 1
     assert handler.s3_client is None
+
+
+def test_get_aws_client_passes_region_to_sts(monkeypatch):
+    captured = {}
+
+    class DummySTSClient:
+        def assume_role(self, **kwargs):
+            captured["assume_role_kwargs"] = kwargs
+            return {
+                "Credentials": {
+                    "AccessKeyId": "assumed-key",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-token",
+                }
+            }
+
+    class DummySession:
+        def __init__(self, **kwargs):
+            captured["session_kwargs"] = kwargs
+
+        def client(self, client_type, **kwargs):
+            captured["session_client_type"] = client_type
+            captured["session_client_kwargs"] = kwargs
+            return object()
+
+    def fake_boto3_client(service_name, **kwargs):
+        captured["sts_service_name"] = service_name
+        captured["sts_client_kwargs"] = kwargs
+        return DummySTSClient()
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://floci.test")
+    monkeypatch.setattr(
+        "opentaskpy.addons.aws.remotehandlers.creds.boto3.client",
+        fake_boto3_client,
+    )
+    monkeypatch.setattr(
+        "opentaskpy.addons.aws.remotehandlers.creds.boto3.session.Session",
+        DummySession,
+    )
+
+    result = get_aws_client(
+        "s3",
+        {
+            "AccessKeyId": "test-key",
+            "SecretAccessKey": "test-secret",
+            "region_name": "eu-west-1",
+        },
+        assume_role_arn="arn:aws:iam::012345678900:role/dummy-role",
+    )
+
+    assert captured["sts_service_name"] == "sts"
+    assert captured["sts_client_kwargs"]["endpoint_url"] == "http://floci.test"
+    assert captured["sts_client_kwargs"]["region_name"] == "eu-west-1"
+    assert captured["assume_role_kwargs"]["RoleArn"] == (
+        "arn:aws:iam::012345678900:role/dummy-role"
+    )
+    assert captured["session_kwargs"]["aws_access_key_id"] == "assumed-key"
+    assert captured["session_client_type"] == "s3"
+    assert captured["session_client_kwargs"]["endpoint_url"] == "http://floci.test"
+    assert result["temporary_creds"]["AccessKeyId"] == "assumed-key"
 
 
 def test_s3_file_watch(s3_client, setup_bucket, tmp_path):

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 import botocore
 import freezegun
 import pytest
+from botocore.config import Config
 from opentaskpy.taskhandlers import transfer
 from pytest_shell import fs
 
@@ -475,6 +476,139 @@ def test_remote_handler():
 
     # dest_remote_handler should be None
     assert transfer_obj.dest_remote_handlers is None
+
+
+def test_s3_transfer_passes_botocore_config(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def close(self):
+            return None
+
+    def fake_get_aws_client(
+        client_type,
+        credentials,
+        token_expiry_seconds=900,
+        assume_role_arn=None,
+        assume_role_external_id=None,
+        config=None,
+    ):
+        captured["client_type"] = client_type
+        captured["credentials"] = credentials
+        captured["token_expiry_seconds"] = token_expiry_seconds
+        captured["assume_role_arn"] = assume_role_arn
+        captured["assume_role_external_id"] = assume_role_external_id
+        captured["config"] = config
+        return {"client": DummyClient(), "temporary_creds": None}
+
+    monkeypatch.setattr(
+        "opentaskpy.addons.aws.remotehandlers.s3.get_aws_client", fake_get_aws_client
+    )
+
+    handler = S3Transfer(
+        {
+            "task_id": "s3-config-test",
+            "bucket": BUCKET_NAME,
+            "directory": "src",
+            "fileRegex": ".*\\.txt",
+            "protocol": {
+                "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+                "botocoreReadTimeout": 120,
+                "botocoreConnectTimeout": 30,
+                "max_attempts": 2,
+            },
+        }
+    )
+
+    assert isinstance(captured["config"], Config)
+    assert captured["client_type"] == "s3"
+    assert captured["config"].read_timeout == 120
+    assert captured["config"].connect_timeout == 30
+    assert captured["config"].retries["max_attempts"] == 2
+    handler.tidy()
+
+
+def test_s3_transfer_uses_default_botocore_config(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def close(self):
+            return None
+
+    def fake_get_aws_client(
+        client_type,
+        credentials,
+        token_expiry_seconds=900,
+        assume_role_arn=None,
+        assume_role_external_id=None,
+        config=None,
+    ):
+        captured["config"] = config
+        return {"client": DummyClient(), "temporary_creds": None}
+
+    monkeypatch.setattr(
+        "opentaskpy.addons.aws.remotehandlers.s3.get_aws_client", fake_get_aws_client
+    )
+
+    handler = S3Transfer(
+        {
+            "task_id": "s3-default-config-test",
+            "bucket": BUCKET_NAME,
+            "directory": "src",
+            "fileRegex": ".*\\.txt",
+            "protocol": {
+                "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+            },
+        }
+    )
+
+    assert isinstance(captured["config"], Config)
+    assert captured["config"].read_timeout == 60
+    assert captured["config"].connect_timeout == 10
+    assert captured["config"].retries["max_attempts"] == 0
+    handler.tidy()
+
+
+def test_s3_transfer_tidy_is_idempotent(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    def fake_get_aws_client(
+        client_type,
+        credentials,
+        token_expiry_seconds=900,
+        assume_role_arn=None,
+        assume_role_external_id=None,
+        config=None,
+    ):
+        return {"client": DummyClient(), "temporary_creds": None}
+
+    monkeypatch.setattr(
+        "opentaskpy.addons.aws.remotehandlers.s3.get_aws_client", fake_get_aws_client
+    )
+
+    handler = S3Transfer(
+        {
+            "task_id": "s3-tidy-test",
+            "bucket": BUCKET_NAME,
+            "directory": "src",
+            "fileRegex": ".*\\.txt",
+            "protocol": {
+                "name": "opentaskpy.addons.aws.remotehandlers.s3.S3Transfer",
+            },
+        }
+    )
+
+    client = handler.s3_client
+    handler.tidy()
+    handler.tidy()
+
+    assert client.close_calls == 1
+    assert handler.s3_client is None
 
 
 def test_s3_file_watch(s3_client, setup_bucket, tmp_path):

--- a/tests/test_remotehandler_s3_transfer.py
+++ b/tests/test_remotehandler_s3_transfer.py
@@ -462,7 +462,7 @@ def setup_bucket(credentials, s3_client):
         subprocess.run(
             ["awslocal", "s3", "rb", f"s3://{bucket}", "--force"], check=False
         )
-        subprocess.run(["awslocal", "s3", "mb", f"s3://{bucket}"], check=False)
+        subprocess.run(["awslocal", "s3", "mb", f"s3://{bucket}"], check=True)
 
 
 def test_remote_handler():

--- a/tests/test_s3_source_schema_validate.py
+++ b/tests/test_s3_source_schema_validate.py
@@ -125,6 +125,11 @@ def test_s3_source_protocol(
     json_data["source"]["protocol"]["token_expiry_seconds"] = 10000
     assert validate_transfer_json(json_data)
 
+    json_data["source"]["protocol"]["botocoreReadTimeout"] = 120
+    json_data["source"]["protocol"]["botocoreConnectTimeout"] = 30
+    json_data["source"]["protocol"]["max_attempts"] = 2
+    assert validate_transfer_json(json_data)
+
     # Set it too low, and too high
     json_data["source"]["protocol"]["token_expiry_seconds"] = 899
     assert not validate_transfer_json(json_data)
@@ -245,6 +250,11 @@ def test_s3_destination(valid_transfer, valid_destination):
 
     # Add flags
     json_data["destination"][0]["flags"] = {"fullPath": "flag.txt"}
+    assert validate_transfer_json(json_data)
+
+    json_data["destination"][0]["protocol"]["botocoreReadTimeout"] = 120
+    json_data["destination"][0]["protocol"]["botocoreConnectTimeout"] = 30
+    json_data["destination"][0]["protocol"]["max_attempts"] = 2
     assert validate_transfer_json(json_data)
 
     # Remove protocol


### PR DESCRIPTION
* Added the option to set botocore timeouts, and specified sensible defaults if not set in transfer/execution
* Fixed bug in `tidy` function throwing exception if client is already closed